### PR TITLE
Add automatic training to helper APIs

### DIFF
--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,5 @@
+setup:
+  - pip install -r web/requirements.txt
+  - pip install -r nb/requirements.txt
+check:
+  - python -m py_compile web/src/diet_classifiers.py nb/src/diet_classifiers.py


### PR DESCRIPTION
## Summary
- train diet models automatically when calling is_keto/is_vegan
- add Codex configuration file

## Testing
- `python -m py_compile web/src/diet_classifiers.py nb/src/diet_classifiers.py`


------
https://chatgpt.com/codex/tasks/task_e_684806161700832bb13f7122ae26c55d