### PR TITLE
Remove duplicate sklearn import

### DIFF
--- a/web/src/diet_classifiers.py
+++ b/web/src/diet_classifiers.py
@@ -48,7 +48,6 @@ from sklearn.svm import LinearSVC
 from sklearn.linear_model import SGDClassifier
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.linear_model import PassiveAggressiveClassifier, RidgeClassifier
-from sklearn.base import BaseEstimator, ClassifierMixin
 from nltk.stem import WordNetLemmatizer
 
 # Download NLTK data


### PR DESCRIPTION
## Summary
- remove redundant sklearn import in diet_classifiers after fallback block

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848114ad59c832bb48622e4783d76fd