### PR TITLE
Add hybrid pipeline with image embeddings

### DIFF
--- a/nb/src/hybrid_classifier.py
+++ b/nb/src/hybrid_classifier.py
@@ -1,0 +1,141 @@
+import argparse
+import os
+from pathlib import Path
+from io import BytesIO
+import requests
+import pandas as pd
+import numpy as np
+from PIL import Image
+import torch
+from torchvision import models, transforms
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import classification_report
+from imblearn.over_sampling import SMOTE
+from scipy.sparse import hstack, csr_matrix
+
+# Import simple heuristics
+from diet_classifiers import is_keto, is_vegan
+
+IMAGE_DIR = Path('data/images')
+EMBED_PATH = Path('data/image_embeddings.npy')
+
+
+def download_images(df: pd.DataFrame) -> None:
+    IMAGE_DIR.mkdir(parents=True, exist_ok=True)
+    for idx, url in df['photo_url'].items():
+        file = IMAGE_DIR / f"{idx}.jpg"
+        if file.exists() or not isinstance(url, str) or not url:
+            continue
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            with open(file, 'wb') as f:
+                f.write(resp.content)
+        except Exception:
+            # Skip failed downloads
+            continue
+
+
+def build_image_embeddings(df: pd.DataFrame, force: bool = False) -> np.ndarray:
+    if EMBED_PATH.exists() and not force:
+        return np.load(EMBED_PATH)
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = models.resnet50(weights=models.ResNet50_Weights.DEFAULT)
+    model.fc = torch.nn.Identity()
+    model.eval()
+    model.to(device)
+    preprocess = transforms.Compose([
+        transforms.Resize(256),
+        transforms.CenterCrop(224),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+    ])
+
+    embeddings = []
+    for idx in df.index:
+        img_file = IMAGE_DIR / f"{idx}.jpg"
+        if not img_file.exists():
+            embeddings.append(np.zeros(2048, dtype=np.float32))
+            continue
+        try:
+            img = Image.open(img_file).convert('RGB')
+            with torch.no_grad():
+                tensor = preprocess(img).unsqueeze(0).to(device)
+                emb = model(tensor).squeeze().cpu().numpy()
+        except Exception:
+            emb = np.zeros(2048, dtype=np.float32)
+        embeddings.append(emb)
+
+    arr = np.vstack(embeddings)
+    np.save(EMBED_PATH, arr)
+    return arr
+
+
+def label_with_rules(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    df['label_keto'] = df['ingredients'].apply(is_keto).astype(int)
+    df['label_vegan'] = df['ingredients'].apply(is_vegan).astype(int)
+    return df
+
+
+def vectorize_text(df: pd.DataFrame) -> tuple:
+    texts = df['ingredients'].apply(lambda x: ' '.join(x) if isinstance(x, list) else str(x))
+    vec = TfidfVectorizer(min_df=2)
+    X = vec.fit_transform(texts)
+    return X, vec
+
+
+def combine_features(X_text, X_image) -> csr_matrix:
+    img_sparse = csr_matrix(X_image)
+    return hstack([X_text, img_sparse])
+
+
+def train_model(X, y):
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    smote = SMOTE(random_state=42)
+    X_res, y_res = smote.fit_resample(X_train, y_train)
+    clf = LogisticRegression(max_iter=1000)
+    clf.fit(X_res, y_res)
+    pred = clf.predict(X_test)
+    print(classification_report(y_test, pred))
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Hybrid text+image diet classifier')
+    parser.add_argument('--data', default='silver.csv', help='CSV with ingredients, photo_url columns')
+    parser.add_argument('--mode', choices=['text', 'image', 'both'], default='both')
+    parser.add_argument('--force', action='store_true', help='Force recompute image embeddings')
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.data)
+    df = label_with_rules(df)
+
+    if args.mode in {'both', 'image'}:
+        download_images(df)
+        img_embs = build_image_embeddings(df, force=args.force)
+    else:
+        img_embs = None
+
+    if args.mode in {'both', 'text'}:
+        X_text, _ = vectorize_text(df)
+    else:
+        X_text = None
+
+    if args.mode == 'text':
+        X = X_text
+    elif args.mode == 'image':
+        X = csr_matrix(img_embs)
+    else:
+        X = combine_features(X_text, img_embs)
+
+    print('=== Keto ===')
+    train_model(X, df['label_keto'])
+    print('=== Vegan ===')
+    train_model(X, df['label_vegan'])
+
+
+if __name__ == '__main__':
+    main()

--- a/web/src/diet_classifiers.py
+++ b/web/src/diet_classifiers.py
@@ -114,6 +114,27 @@ with warnings.catch_warnings():
     except ImportError:
         lgb = None
 
+# Optional PyTorch for image embeddings
+try:  # pragma: no cover - optional dependency
+    from PIL import Image
+    import requests
+    import torch
+    from torchvision import models, transforms
+    TORCH_AVAILABLE = True
+except Exception as e:  # pragma: no cover - optional dependency
+    warnings.warn(
+        f"PyTorch/torchvision not installed ({e}). Image features disabled.",
+        stacklevel=2,
+    )
+    Image = None  # type: ignore
+    requests = None  # type: ignore
+    torch = None  # type: ignore
+    models = None  # type: ignore
+    transforms = None  # type: ignore
+    TORCH_AVAILABLE = False
+
+from scipy.sparse import hstack, csr_matrix
+
 # ============================================================================
 # DOMAIN HARDCODED LISTS (HEURISTICS) - Complete from original
 # ============================================================================
@@ -591,6 +612,7 @@ class Config:
     })
     vec_kwargs: Dict[str, Any] = field(default_factory=lambda: dict(
         min_df=2, ngram_range=(1, 3), max_features=50000, sublinear_tf=True))
+    image_dir: Path = Path("dataset/arg_max/images")
 
 
 CFG = Config()
@@ -734,6 +756,78 @@ def load_datasets() -> tuple[pd.DataFrame, pd.DataFrame]:
     recipes = pd.read_parquet(CFG.url_map["allrecipes.parquet"])
     ground_truth = pd.read_csv(CFG.url_map["ground_truth_sample.csv"])
     return recipes, ground_truth
+
+
+def _download_images(df: pd.DataFrame, split: str) -> None:
+    """Download images to the configured image directory."""
+    if not TORCH_AVAILABLE:
+        return
+    img_dir = CFG.image_dir / split
+    img_dir.mkdir(parents=True, exist_ok=True)
+    if 'photo_url' not in df.columns:
+        return
+    for idx, url in df['photo_url'].items():
+        f = img_dir / f"{idx}.jpg"
+        if f.exists() or not isinstance(url, str) or not url:
+            continue
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            with open(f, 'wb') as fh:
+                fh.write(resp.content)
+        except Exception:
+            continue
+
+
+def build_image_embeddings(df: pd.DataFrame, split: str, force: bool = False) -> np.ndarray:
+    """Return or compute image embeddings for the given dataframe."""
+    if not TORCH_AVAILABLE:
+        return np.zeros((len(df), 2048), dtype=np.float32)
+
+    img_dir = CFG.image_dir / split
+    embed_path = img_dir / "embeddings.npy"
+    if embed_path.exists() and not force:
+        return np.load(embed_path)
+
+    _download_images(df, split)
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = models.resnet50(weights=models.ResNet50_Weights.DEFAULT)
+    model.fc = torch.nn.Identity()
+    model.eval()
+    model.to(device)
+    preprocess = transforms.Compose([
+        transforms.Resize(256),
+        transforms.CenterCrop(224),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=[0.485, 0.456, 0.406],
+                             std=[0.229, 0.224, 0.225]),
+    ])
+
+    vectors = []
+    for idx in df.index:
+        img_file = img_dir / f"{idx}.jpg"
+        if not img_file.exists():
+            vectors.append(np.zeros(2048, dtype=np.float32))
+            continue
+        try:
+            img = Image.open(img_file).convert('RGB')
+            with torch.no_grad():
+                t = preprocess(img).unsqueeze(0).to(device)
+                vec = model(t).squeeze().cpu().numpy()
+        except Exception:
+            vec = np.zeros(2048, dtype=np.float32)
+        vectors.append(vec)
+
+    arr = np.vstack(vectors)
+    np.save(embed_path, arr)
+    return arr
+
+
+def combine_features(X_text, X_image) -> csr_matrix:
+    """Concatenate sparse text matrix with dense image array."""
+    img_sparse = csr_matrix(X_image)
+    return hstack([X_text, img_sparse])
 
 
 
@@ -1137,8 +1231,13 @@ def top_n(task, res, X_vec, clean, X_gold, silver, gold, n=3, use_saved_params=F
 # ============================================================================
 
 
-def run_full_pipeline():
-    """Run the complete training and evaluation pipeline."""
+def run_full_pipeline(mode: str = "both", force: bool = False):
+    """Run the complete training and evaluation pipeline.
+
+    Args:
+        mode: 'text', 'image', or 'both' to specify feature set.
+        force: Recompute image embeddings even if cached.
+    """
     # Load datasets in memory
     recipes, gold = load_datasets()
     gold["label_keto"] = gold.filter(regex="keto").iloc[:, 0].astype(int)
@@ -1150,10 +1249,26 @@ def run_full_pipeline():
     show_balance(gold, "Gold")
     show_balance(silver, "Silver")
 
-    # Vectorize
     vec = TfidfVectorizer(**CFG.vec_kwargs)
-    X_silver = vec.fit_transform(silver.clean)
-    X_gold = vec.transform(gold.clean)
+    X_text_silver = vec.fit_transform(silver.clean)
+    X_text_gold = vec.transform(gold.clean)
+
+    # Image embeddings if requested
+    if mode in {"image", "both"}:
+        img_silver = build_image_embeddings(recipes, "silver", force=force)
+        img_gold = build_image_embeddings(gold, "gold", force=force)
+    else:
+        img_silver = img_gold = None
+
+    if mode == "text":
+        X_silver = X_text_silver
+        X_gold = X_text_gold
+    elif mode == "image":
+        X_silver = csr_matrix(img_silver)
+        X_gold = csr_matrix(img_gold)
+    else:
+        X_silver = combine_features(X_text_silver, img_silver)
+        X_gold = combine_features(X_text_gold, img_gold)
 
     # Run mode A
     res = run_mode_A(X_silver, gold.clean, X_gold, silver, gold)
@@ -1200,8 +1315,8 @@ def _ensure_pipeline():
                 with open(models_path, 'rb') as f:
                     _pipeline_state['models'] = pickle.load(f)
             else:
-                # No trained models available, run full pipeline
-                vec, _, _, res = run_full_pipeline()
+                # No trained models available, run full pipeline with images
+                vec, _, _, res = run_full_pipeline(mode="both")
 
                 # Select best models as done in CLI training
                 best_models = {}
@@ -1388,6 +1503,10 @@ def main():
                         help='Run full training pipeline')
     parser.add_argument('--ingredients', type=str,
                         help='Comma separated ingredients to classify')
+    parser.add_argument('--mode', choices=['text', 'image', 'both'],
+                        default='both', help='Feature mode for training')
+    parser.add_argument('--force', action='store_true',
+                        help='Recompute image embeddings')
     args = parser.parse_args()
 
     if args.ingredients:
@@ -1402,8 +1521,8 @@ def main():
         return
 
     elif args.train:
-        # Run full pipeline
-        vec, silver, gold, res = run_full_pipeline()
+        # Run full pipeline with selected feature mode
+        vec, silver, gold, res = run_full_pipeline(mode=args.mode, force=args.force)
 
         # Save models
         try:
@@ -1491,7 +1610,7 @@ def main():
 
     else:
         # Run full pipeline in dev mode
-        run_full_pipeline()
+        run_full_pipeline(mode=args.mode, force=args.force)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend Config with image directory
- add helper functions to download photos and build ResNet50 embeddings
- support `text`, `image`, or `both` modes in `run_full_pipeline`
- expose feature mode and force flag on command line

## Testing
- `python -m py_compile web/src/diet_classifiers.py nb/src/diet_classifiers.py nb/src/hybrid_classifier.py`

------
https://chatgpt.com/codex/tasks/task_e_684852001af8832bbbb02cfe1a3c7623