### PR TITLE
Fix fallback for vectorizer in diet classifiers

### DIFF
--- a/web/src/diet_classifiers.py
+++ b/web/src/diet_classifiers.py
@@ -1276,11 +1276,11 @@ def is_ingredient_keto(ingredient: str) -> bool:
             try:
                 X = _pipeline_state['vectorizer'].transform([normalized])
                 prob = model.predict_proba(X)[0, 1]
-            except:
-                # Fallback to rule-based
-                prob = model.predict_proba([normalized])[0, 1]
+            except Exception as e:
+                log.warning("Vectorizer failed: %s. Using rule-based fallback.", e)
+                prob = RuleModel("keto", RX_KETO, RX_WL_KETO).predict_proba([normalized])[0, 1]
         else:
-            prob = model.predict_proba([normalized])[0, 1]
+            prob = RuleModel("keto", RX_KETO, RX_WL_KETO).predict_proba([normalized])[0, 1]
 
         # Apply verification
         prob_adj = verify_with_rules(
@@ -1325,11 +1325,11 @@ def is_ingredient_vegan(ingredient: str) -> bool:
             try:
                 X = _pipeline_state['vectorizer'].transform([normalized])
                 prob = model.predict_proba(X)[0, 1]
-            except:
-                # Fallback to rule-based
-                prob = model.predict_proba([normalized])[0, 1]
+            except Exception as e:
+                log.warning("Vectorizer failed: %s. Using rule-based fallback.", e)
+                prob = RuleModel("vegan", RX_VEGAN, RX_WL_VEGAN).predict_proba([normalized])[0, 1]
         else:
-            prob = model.predict_proba([normalized])[0, 1]
+            prob = RuleModel("vegan", RX_VEGAN, RX_WL_VEGAN).predict_proba([normalized])[0, 1]
 
         # Apply verification
         prob_adj = verify_with_rules(


### PR DESCRIPTION
## Summary
- handle missing vectorizer correctly when scoring ingredients

## Testing
- `python -m py_compile web/src/diet_classifiers.py nb/src/diet_classifiers.py`


------
https://chatgpt.com/codex/tasks/task_e_684851c6acac832b8a8daca3f2f389a4